### PR TITLE
Add HTTPS to make link clickable

### DIFF
--- a/src/genpage.js
+++ b/src/genpage.js
@@ -85,7 +85,7 @@ module.exports = {
             let domain = ""
             if (story.url != undefined) domain = " (" + new URL(story.url).hostname.replace("www.","") + ")"
             
-            out.push(`${BOLD}➥${RESET}    ▴${sc+s+RESET+" ".repeat(4 - s.toString().length)}➤ ${HKKR_URL}hkkr.in/${story.id}${RESET+URL_C}${domain+RESET}\n`)
+            out.push(`${BOLD}➥${RESET}    ▴${sc+s+RESET+" ".repeat(4 - s.toString().length)}➤ https://${HKKR_URL}/${story.id}${RESET+URL_C}${domain+RESET}\n`)
 
           })
         


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19589006/189175629-8b267cee-924c-4181-823a-f431f22bd7ae.png)

by default those https://hkkr.in links aren't clickable because they don't have the protocol - I added them so I can visit the page right from my terminal